### PR TITLE
Improve Test for PortList

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -84,7 +84,7 @@ func TestAllUnavailablePortsFromList(t *testing.T) {
 	networker := network.NewNetwork(nil, localNet)
 
 	list := networker.AllUnavailablePorts()
-	assert.Equal(t, network.PortList([]int{3000, 4000, 5000}), list)
+	assert.Equal(t, network.PortList{3000, 4000, 5000}, list)
 }
 
 func TestPortIsAvailableWithoutError(t *testing.T) {

--- a/network/portlist.go
+++ b/network/portlist.go
@@ -21,10 +21,12 @@ func (pl *PortList) String() string {
  */
 func (pl *PortList) Set(value string) error {
 	convertStringArrayToPortlist := func(strArr []string) PortList {
-		var list PortList
+		list := PortList{}
 		for _, str := range strArr {
-			port, _ := strconv.Atoi(str)
-			list = append(list, port)
+			port, err := strconv.Atoi(str)
+			if err == nil {
+				list = append(list, port)
+			}
 		}
 		return list
 	}

--- a/network/portlist_test.go
+++ b/network/portlist_test.go
@@ -1,27 +1,63 @@
-package network
+package network_test
 
 import (
-	"reflect"
 	"testing"
+
+	"."
+
+	"github.com/stretchr/testify/assert"
 )
 
-var (
-	portListTest            = PortList([]int{1000, 2000, 3000})
-	portListTestString      = "[1000 2000 3000]"
-	portListTestStringArray = "1000,2000,3000"
-)
+type testCasePortList struct {
+	list            network.PortList
+	listString      string
+	listStringArray string
+}
+
+var testCasesPortList = []testCasePortList{
+	{
+		list:            network.PortList{},
+		listString:      "[]",
+		listStringArray: "",
+	},
+	{
+		list:            network.PortList{0},
+		listString:      "[0]",
+		listStringArray: "0",
+	},
+	{
+		list:            network.PortList{3000},
+		listString:      "[3000]",
+		listStringArray: "3000",
+	},
+	{
+		list:            network.PortList{3000, 4000, 5000},
+		listString:      "[3000 4000 5000]",
+		listStringArray: "3000,4000,5000",
+	},
+	{
+		list:            network.PortList{},
+		listString:      "[]",
+		listStringArray: "love",
+	},
+	{
+		list:            network.PortList{8080},
+		listString:      "[8080]",
+		listStringArray: "love,8080",
+	},
+}
 
 func TestPortListString(t *testing.T) {
-	str := portListTest.String()
-	if str != portListTestString {
-		t.Errorf("Expect %s, but get %s", portListTestString, str)
+	for _, test := range testCasesPortList {
+		assert.Equal(t, test.listString, test.list.String())
 	}
 }
 
 func TestPortListSet(t *testing.T) {
-	list := portListTest
-	list.Set(portListTestStringArray)
-	if !reflect.DeepEqual(list, portListTest) {
-		t.Errorf("Expect %v, but get %v", portListTest, list)
+	for _, test := range testCasesPortList {
+		var portList network.PortList
+		err := portList.Set(test.listStringArray)
+		assert.NoError(t, err)
+		assert.Equal(t, test.list, portList)
 	}
 }


### PR DESCRIPTION
Using [`assert`](https://github.com/stretchr/testify/tree/master/assert) package to test **PortList**, which make the test code more clean. Moreover, add more test cases. The result is 100% coverage on `network/portlist.go`.